### PR TITLE
Update-maildevVisitMessageById

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-maildev",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-maildev",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "wait-on": "^7.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-maildev",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "An easy-to-use cypress bunch of commands to use Maildev API for tests messages reception !",
   "main": "./build/index.js",
   "repository": "https://github.com/Clebiez/cypress-maildev.git",

--- a/src/maildevCommands.ts
+++ b/src/maildevCommands.ts
@@ -50,7 +50,9 @@ export class MaildevCommands {
   }
 
   maildevVisitMessageById(id: string): void {
-    cy.visit(`${this.baseUrl}/email/${id}/html`);
+    cy.origin(`${this.baseUrl}`, { args: { id } }, ({ id }) => {
+      cy.visit(`/email/${id}/html`);
+    });
   }
 
   maildevGetMessageBySubject(str: string): Cypress.Chainable<Email> {


### PR DESCRIPTION
due to mail dev usually another baseUrl than test project navigation to it should be done via cy.origin